### PR TITLE
fix for windows skipping processing of touch and mouse data

### DIFF
--- a/Graphics/Window.cs
+++ b/Graphics/Window.cs
@@ -142,7 +142,7 @@ namespace Backbone.Graphics
 
         public void HandleMouse(HandleMouseCommand command)
         {
-            if(settings.VisibleWhileInactive && command.State == MouseEvent.Release)
+            if(!settings.VisibleWhileInactive || command.State == MouseEvent.Release)
             {
                 // Handle click of backpanel, if set up to do something
                 // TODO: need to make this a 2D rectangular collision instead of ray to sphere collision. Okay-ish for now,


### PR DESCRIPTION
Not all windows were processing mouse input, as there was an errant boolean that was preventing it. This should fix that.