### PR TITLE
Add reposition action and also let window be drawn while animating.

### DIFF
--- a/Actions/ActionBuilder.cs
+++ b/Actions/ActionBuilder.cs
@@ -110,5 +110,16 @@ namespace Backbone.Actions
         {
             return new ColorAction(startColor, endColor, duration);
         }
+
+        /// <summary>
+        /// Reposition an object immediately, no lerping or updates or duration. Had too many issues with 
+        /// the normal move action with a tiny duration to work like this, figured it's best just to add this and make it simple
+        /// </summary>
+        /// <param name="position">The new position to update the movable to.</param>
+        /// <returns>The reposition action.</returns>
+        internal static IAction3D Reposition(Vector3 position)
+        {
+            return new RepositionAction(position);
+        }
     }
 }

--- a/Actions/RepositionAction.cs
+++ b/Actions/RepositionAction.cs
@@ -1,0 +1,37 @@
+﻿using Backbone.Actions;
+using Backbone.Graphics;
+using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Backbone.Actions
+{
+    public class RepositionAction : IAction3D
+    {
+        public List<IAction3D> SubActions { get; set; }
+
+        private Vector3 newPosition { get; set; }
+
+        public RepositionAction(Vector3 newPosition)
+        {
+            this.newPosition = newPosition;
+        }
+
+        public void Reset()
+        {
+            if (SubActions != null)
+            {
+                SubActions.ForEach(x => x.Reset());
+            }
+        }
+
+        public bool Update(Movable3D movable, GameTime gameTime)
+        {
+            movable.UpdatePosition(newPosition);
+            return true;
+        }
+    }
+}

--- a/Graphics/Window.cs
+++ b/Graphics/Window.cs
@@ -26,6 +26,9 @@ namespace Backbone.Graphics
         private MenuContainer Menu { get; set; }
 
         public bool IsActive { get; set; } = false;
+        public Vector3 InactivePosition { get; set; }
+        public Vector3 ActivePosition { get; set; }
+        public float TransitionDuraton { get; set; }
 
         public bool IsAnimating
         {
@@ -57,6 +60,10 @@ namespace Backbone.Graphics
         public Window(WindowSettings<T> settings)
         {
             this.settings = settings;
+
+            InactivePosition = settings.InactivePosition;
+            ActivePosition = settings.ActivePosition;
+            TransitionDuraton = settings.TransitionDuration;
 
             Size = settings.Size;
 
@@ -122,7 +129,7 @@ namespace Backbone.Graphics
 
         public void Draw(Matrix view, Matrix projection)
         {
-            if(settings.VisibleWhileInactive || IsActive)
+            if(settings.VisibleWhileInactive || IsActive || IsAnimating)
             {
                 BackPanel.Draw(view, projection);
 

--- a/Menus/MenuContainer.cs
+++ b/Menus/MenuContainer.cs
@@ -140,6 +140,7 @@ namespace Backbone.Menus
                     throw new System.Exception("Check the code, shouldn't be an issue");
                 #endif
             }
+            return null;
         }
 
         public object GetValue()


### PR DESCRIPTION
I have a pause menu and it wasn't showing its transition out animation. That ended up being because it was being set to inactive right away and was skipping the draw as a result, even though it shouldn't be because it's animating. So I added a check for that.

I also added a Reposition action, that's like a moveTo except it's instant, no lerping or duration. There are times when I want somethiung to reposition in an animation right away, but trying to do it with the moveTo with a tiny 0.0001 duration didn't seem to work very well. So I'll just use this instead, much simpler. For this, I needed it to move the pause window off the right side of the screen then immediately reposition it to the left side offscreen to be ready for the next transition in animation.