### PR TITLE
Fix for icon chooser not being on release and grid always using 0 for…

### DIFF
--- a/Graphics/IconChooser.cs
+++ b/Graphics/IconChooser.cs
@@ -74,7 +74,7 @@ namespace Backbone.Graphics
 
         public void HandleMouse(HandleMouseCommand command)
         {
-            if(command.State == MouseEvent.Pressed && Icon != null && Icon.IsInteractive)
+            if(command.State == MouseEvent.Release && Icon != null && Icon.IsInteractive)
             {
                 if (Icon.Intersects(command.Viewport, command.WorldPosition, Vector2.Zero, command.Ratio, OverrideCollisionRadius))
                 {

--- a/Graphics/IconGridChooser.cs
+++ b/Graphics/IconGridChooser.cs
@@ -68,7 +68,7 @@ namespace ProximityND.Backbone.Graphics
                 icon.icon.UpdatePosition(new Vector3(
                     basePosition.X + column * (iconSize + gapSize),
                     basePosition.Y - row * (iconSize + gapSize),
-                    0f));
+                    basePosition.Z));
             }
 
             if(icons.Count > 0)


### PR DESCRIPTION
Icon chooser was cycling like crazy because it was on pressed. I think the recent changes with the input helper class enabled this to start happening. Switched to release and working as expected again.

Also for the Icon Grid I needed to adjust the Z position and realized it was always being set to zero here instead of checking the initial Z position, so I switched it. Shouldn't have ever just been 0 to begin with.