### PR TITLE
Fix color add propery action

### DIFF
--- a/Actions/ActionBuilder.cs
+++ b/Actions/ActionBuilder.cs
@@ -96,6 +96,22 @@ namespace Backbone.Actions
             return new ChangeScreenAction<T>(switchToScreen);
         }
 
+        /// <summary>
+        /// Takes in an object, a string name of a property on that object, and a new value, and will change the property of that object
+        /// Will immediately make that change and finish the action.
+        /// Mainly used to adjust a value during an existing sequence of actions, either after a set delay, or more likely in the middle of an
+        /// animation.
+        /// </summary>
+        /// <typeparam name="T">The type for the property value.</typeparam>
+        /// <param name="targetObject">The object that has the property we want to change.</param>
+        /// <param name="propertyName">The name of the property on the object we want to change.</param>
+        /// <param name="newPropertyValue">The new value we want that property to become.</param>
+        /// <returns></returns>
+        public static IAction3D ChangeObjectProperty<T>(object targetObject, string propertyName, T newPropertyValue)
+        {
+            return new ChangeObjectPropertyAction<T>(targetObject, propertyName, newPropertyValue);
+        }
+
         public static IAction3D AddVelocity(Vector3 v0, Vector3 p0, float g, float duration)
         {
             return new PhysicsParticleAction(v0, p0, g, duration);

--- a/Actions/ChangeObjectPropertyAction.cs
+++ b/Actions/ChangeObjectPropertyAction.cs
@@ -1,0 +1,48 @@
+﻿using Backbone.Actions;
+using Backbone.Graphics;
+using Backbone.RPG;
+using Microsoft.Xna.Framework;
+using SharpDX.Direct3D9;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ProximityND.Backbone.Actions
+{
+    /// <summary>
+    /// Takes in an object, a string name of a property on that object, and a new value, and will change the property of that object
+    /// Will immediately make that change and finish the action.
+    /// Mainly used to adjust a value during an existing sequence of actions, either after a set delay, or more likely in the middle of an
+    /// animation.
+    /// </summary>
+    public class ChangeObjectPropertyAction<T> : IAction3D
+    {
+        public List<IAction3D> SubActions { get; set; }
+
+        object targetObject;
+        string propertyName;
+        T newPropertyValue;
+
+        public ChangeObjectPropertyAction(object targetObject, string propertyName, T newPropertyValue)
+        {
+            this.targetObject = targetObject;
+            this.propertyName = propertyName;
+            this.newPropertyValue = newPropertyValue;
+        }
+
+        public void Reset()
+        {
+        }
+
+        public bool Update(Movable3D movable, GameTime gameTime)
+        {
+            var objType = targetObject.GetType();
+            PropertyInfo propertyInfo = objType.GetProperty(propertyName);
+            propertyInfo.SetValue(targetObject, Convert.ChangeType(newPropertyValue, propertyInfo.PropertyType), null);
+            return true;
+        }
+    }
+}

--- a/Actions/ColorAction.cs
+++ b/Actions/ColorAction.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 
 namespace ProximityND.Backbone.Actions
 {
+    // TODO: make this generic and not just based on color1 and color2 (use mesh color properties instead)
     public class ColorAction : IAction3D
     {
         Color sourceColor;

--- a/Actions/ColorAction.cs
+++ b/Actions/ColorAction.cs
@@ -2,6 +2,7 @@
 using Backbone.Graphics;
 using Microsoft.Xna.Framework;
 using System.Collections.Generic;
+using System.Diagnostics;
 using static Backbone.Actions.RotateAction;
 
 namespace ProximityND.Backbone.Actions
@@ -44,8 +45,11 @@ namespace ProximityND.Backbone.Actions
             float elapsed = (float)gameTime.ElapsedGameTime.TotalSeconds;
             elapsedTime += elapsed;
 
-            float percent = ActionMath.LerpFloat(elapsed, 0f, 1f, duration);
+            float percent = ActionMath.LerpFloat(elapsedTime, 0f, 1f, duration);
             Color currentColor = Color.Lerp(sourceColor, targetColor, percent);
+
+            var debugColor = ColorHex.ConvertFromColor(currentColor);
+            Debug.WriteLine(debugColor);
 
             string colorHexString = ColorHex.ConvertFromColor(currentColor);
 

--- a/Actions/ColorAction.cs
+++ b/Actions/ColorAction.cs
@@ -2,8 +2,6 @@
 using Backbone.Graphics;
 using Microsoft.Xna.Framework;
 using System.Collections.Generic;
-using System.Diagnostics;
-using static Backbone.Actions.RotateAction;
 
 namespace ProximityND.Backbone.Actions
 {
@@ -49,7 +47,6 @@ namespace ProximityND.Backbone.Actions
             Color currentColor = Color.Lerp(sourceColor, targetColor, percent);
 
             var debugColor = ColorHex.ConvertFromColor(currentColor);
-            Debug.WriteLine(debugColor);
 
             string colorHexString = ColorHex.ConvertFromColor(currentColor);
 

--- a/Graphics/IMenuCard.cs
+++ b/Graphics/IMenuCard.cs
@@ -13,6 +13,7 @@ namespace Backbone.Graphics
         public float Width { get; set; }
         public float Height { get; set; }        
         public string Title { get; set; }
+        public object Data { get; set; }
         void Draw(Matrix view, Matrix projection);
         void SetData(object data);
         void Update(GameTime gameTime);

--- a/Graphics/Movable3D.cs
+++ b/Graphics/Movable3D.cs
@@ -61,8 +61,8 @@ namespace Backbone.Graphics
 
         private List<IAction3D> queuedActions = new List<IAction3D>();
 
-        public string Color1 = ColorHex.DefaultColorHexCodes[ColorType.White];
-        public string Color2 = ColorHex.DefaultColorHexCodes[ColorType.White];
+        public string Color1 { get; set; } = ColorHex.DefaultColorHexCodes[ColorType.White];
+        public string Color2 { get; set; } = ColorHex.DefaultColorHexCodes[ColorType.White];
         //public string ColorBkg = ColorHex.DefaultColorHexCodes[ColorType.Gray];
         public string ColorText = ColorHex.DefaultColorHexCodes[ColorType.DefaultText];
 


### PR DESCRIPTION
Fixed the issue with the color change action. It was referring to 'elapsed' instead of 'elapsedTime' for determining its percent complete, and so was always thinking it was immediately finished.

Also added an action that can change a property on an object (make sure it has getters and setters or it won't be able to grab it), and change to a new property. I added this because sometimes I don't want a value to change until after a certain part of an animation, so this allows me to stick it into the animation sequence.