### PR TITLE
Add movable setting action

### DIFF
--- a/Actions/ActionBuilder.cs
+++ b/Actions/ActionBuilder.cs
@@ -91,6 +91,11 @@ namespace Backbone.Actions
             return new ChangeModelAction(newModel);
         }
 
+        public static IAction3D ChangeMovableSettings(MovableSettings settings)
+        {
+            return new ChangeMovableSettingsAction(settings);
+        }
+
         public static IAction3D ChangeScreen<T>(T switchToScreen)
         {
             return new ChangeScreenAction<T>(switchToScreen);

--- a/Actions/ChangeMovableSettingsAction.cs
+++ b/Actions/ChangeMovableSettingsAction.cs
@@ -48,7 +48,10 @@ namespace Backbone.Actions
                 else
                 {
                     PropertyInfo propertyInfo = objType.GetProperty(kvp.Key);
-                    propertyInfo.SetValue(movable, Convert.ChangeType(kvp.Value, propertyInfo.PropertyType), null);
+                    if(propertyInfo != null)
+                    {
+                        propertyInfo.SetValue(movable, Convert.ChangeType(kvp.Value, propertyInfo.PropertyType), null);
+                    }
                 }
             }
         }

--- a/Actions/ChangeMovableSettingsAction.cs
+++ b/Actions/ChangeMovableSettingsAction.cs
@@ -1,0 +1,46 @@
+﻿using Backbone.Graphics;
+using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Backbone.Actions
+{
+    internal class ChangeMovableSettingsAction : IAction3D
+    {
+        public List<IAction3D> SubActions { get; set; }
+
+        MovableSettings movableSettings;
+
+        public ChangeMovableSettingsAction(MovableSettings movableSettings)
+        {
+            this.movableSettings = movableSettings;
+        }
+
+        public void Reset()
+        {
+        }
+
+        public bool Update(Movable3D movable, GameTime gameTime)
+        {
+            movable.Model = movableSettings.Model;
+            movable.MeshProperties = movableSettings.MeshProperties;
+
+            var objType = movable.GetType();
+
+            foreach (var kvp in movableSettings.Properties)
+            {
+                if(kvp.Key.ToUpper() == "ALPHA")
+                {
+                    movable.SetAlpha((float)kvp.Value);
+                } else
+                {
+                    PropertyInfo propertyInfo = objType.GetProperty(kvp.Key);
+                    propertyInfo.SetValue(movable, Convert.ChangeType(kvp.Value, propertyInfo.PropertyType), null);
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/Actions/ChangeMovableSettingsAction.cs
+++ b/Actions/ChangeMovableSettingsAction.cs
@@ -23,24 +23,34 @@ namespace Backbone.Actions
 
         public bool Update(Movable3D movable, GameTime gameTime)
         {
-            movable.Model = movableSettings.Model;
-            movable.MeshProperties = movableSettings.MeshProperties;
+            Execute(movable, movableSettings);
+            return true;
+        }
+
+        /// <summary>
+        /// Can call this directly and externally to change settings on a movable
+        /// </summary>
+        /// <param name="movable">The movable that needs its settings changed</param>
+        /// <param name="settings">The settings you'd like to change on the movable</param>
+        public static void Execute(Movable3D movable, MovableSettings settings)
+        {
+            movable.Model = settings.Model;
+            movable.MeshProperties = settings.MeshProperties;
 
             var objType = movable.GetType();
 
-            foreach (var kvp in movableSettings.Properties)
+            foreach (var kvp in settings.Properties)
             {
-                if(kvp.Key.ToUpper() == "ALPHA")
+                if (kvp.Key.ToUpper() == "ALPHA")
                 {
                     movable.SetAlpha((float)kvp.Value);
-                } else
+                }
+                else
                 {
                     PropertyInfo propertyInfo = objType.GetProperty(kvp.Key);
                     propertyInfo.SetValue(movable, Convert.ChangeType(kvp.Value, propertyInfo.PropertyType), null);
                 }
             }
-
-            return true;
         }
     }
 }

--- a/Actions/MovableSettings.cs
+++ b/Actions/MovableSettings.cs
@@ -9,5 +9,6 @@ namespace Backbone.Actions
         public Model Model { get; set; }
         public Dictionary<string, MeshProperty> MeshProperties { get; set; } = new Dictionary<string, MeshProperty>();
         public Dictionary<string, object> Properties { get; set; } = new Dictionary<string, object>();
+        public bool IsOccupied { get; set; }
     }
 }

--- a/Actions/MovableSettings.cs
+++ b/Actions/MovableSettings.cs
@@ -1,0 +1,13 @@
+﻿using Backbone.Graphics;
+using Microsoft.Xna.Framework.Graphics;
+using System.Collections.Generic;
+
+namespace Backbone.Actions
+{
+    public class MovableSettings
+    {
+        public Model Model { get; set; }
+        public Dictionary<string, MeshProperty> MeshProperties { get; set; } = new Dictionary<string, MeshProperty>();
+        public Dictionary<string, object> Properties { get; set; } = new Dictionary<string, object>();
+    }
+}

--- a/Actions/MovableSettings.cs
+++ b/Actions/MovableSettings.cs
@@ -9,6 +9,5 @@ namespace Backbone.Actions
         public Model Model { get; set; }
         public Dictionary<string, MeshProperty> MeshProperties { get; set; } = new Dictionary<string, MeshProperty>();
         public Dictionary<string, object> Properties { get; set; } = new Dictionary<string, object>();
-        public bool IsOccupied { get; set; }
     }
 }

--- a/Graphics/Movable3D.cs
+++ b/Graphics/Movable3D.cs
@@ -64,7 +64,7 @@ namespace Backbone.Graphics
         public string Color1 { get; set; } = ColorHex.DefaultColorHexCodes[ColorType.White];
         public string Color2 { get; set; } = ColorHex.DefaultColorHexCodes[ColorType.White];
         //public string ColorBkg = ColorHex.DefaultColorHexCodes[ColorType.Gray];
-        public string ColorText = ColorHex.DefaultColorHexCodes[ColorType.DefaultText];
+        public string ColorText { get; set; } = ColorHex.DefaultColorHexCodes[ColorType.DefaultText];
 
         public Movable3D(Model model, Vector3 startPosition, float scale)
         {


### PR DESCRIPTION
Adds the ability to change the public properties, mesh properties, and model of a Movable within an action, so it can be updated within a sequence of animations. Also let the action be called externally, so I can call it immediately without needing to create and run an animation on it. More of the actions should have a way to execute them manually.

This came in handy in my Proximity game for creating a tile factory that let me set a bunch of properties for a movable and then call this to update everything all at once, and then within my maps I could call it each time I needed it to swap to new tiles.