### PR TITLE
Update color change action to accept any meshname.

### DIFF
--- a/Actions/ActionBuilder.cs
+++ b/Actions/ActionBuilder.cs
@@ -2,6 +2,7 @@
 using Microsoft.Xna.Framework.Graphics;
 using ProximityND.Backbone.Actions;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Backbone.Actions
@@ -127,9 +128,9 @@ namespace Backbone.Actions
             return new RumbleAction(playerIndex, leftMotor, rightMotor, duration);
         }
 
-        internal static IAction3D ChangeColor(Color startColor, Color endColor, float duration)
+        internal static IAction3D ChangeColor(string startColor, string endColor, List<string> meshNames, float duration)
         {
-            return new ColorAction(startColor, endColor, duration);
+            return new ColorAction(startColor, endColor, meshNames, duration);
         }
 
         /// <summary>

--- a/Actions/ColorAction.cs
+++ b/Actions/ColorAction.cs
@@ -13,10 +13,14 @@ namespace ProximityND.Backbone.Actions
         float duration;
         float elapsedTime = 0f;
 
-        public ColorAction(string source, string target, float duration)
+        private List<string> meshNames = new List<string>(); //names of meshes to adjust
+
+        public ColorAction(string source, string target, List<string> meshNames, float duration)
         {
             sourceColor = ColorHex.ConvertFromHex(source);
             targetColor = ColorHex.ConvertFromHex(target);
+
+            this.meshNames = meshNames;
             this.duration = duration;
         }
 
@@ -47,12 +51,24 @@ namespace ProximityND.Backbone.Actions
             float percent = ActionMath.LerpFloat(elapsedTime, 0f, 1f, duration);
             Color currentColor = Color.Lerp(sourceColor, targetColor, percent);
 
-            var debugColor = ColorHex.ConvertFromColor(currentColor);
-
             string colorHexString = ColorHex.ConvertFromColor(currentColor);
 
-            movable.Color1 = colorHexString;
-            movable.Color2 = colorHexString;
+            // apply new color to all meshNames
+            meshNames.ForEach(mesh =>
+            {
+                if (mesh.Equals("Color1"))
+                {
+                    movable.Color1 = colorHexString;
+                }
+                else if (mesh.Equals("Color2"))
+                {
+                    movable.Color2 = colorHexString;
+                }
+                else
+                {
+                    movable.UpdateColor(mesh, colorHexString);
+                }
+            });
 
             return (elapsedTime >= duration);
         }


### PR DESCRIPTION
Need this in order to change the colors of my wall/barrier tiles in Proximity. Also makes it more generic. Still keeping special cases for Color1 and Color2 until those are transferred into meshproperties, though.

Used for this: https://github.com/bacable/ProximityND/issues/176