### PR TITLE
fix several crash errors that are popping up

### DIFF
--- a/Graphics/ModelHelper.cs
+++ b/Graphics/ModelHelper.cs
@@ -8,6 +8,8 @@ namespace Backbone.Graphics
     {
         public static void Draw(ModelDrawSettings settings)
         {
+            if (settings.Model == null) return;
+
             foreach (ModelMesh mesh in settings.Model.Meshes)
             {
 

--- a/Graphics/Movable3D.cs
+++ b/Graphics/Movable3D.cs
@@ -102,8 +102,10 @@ namespace Backbone.Graphics
             if(queuedActions != null && queuedActions.Count > 0)
             {
                 var currentAction = queuedActions[0];
+                
                 // if true, it's finished with the animation
-                if(currentAction.Update(this, gameTime))
+                // NOTE: Somehow even with a valid queuedAction the currentAction became null when debugging, so I'm checking it again here
+                if(currentAction != null && currentAction.Update(this, gameTime))
                 {
                     queuedActions.Remove(currentAction);
                 }

--- a/Graphics/TextGroup.cs
+++ b/Graphics/TextGroup.cs
@@ -263,7 +263,13 @@ namespace Backbone.Graphics
 
         public void Draw(Matrix view, Matrix projection)
         {
-            Letters.ForEach(x => x.Draw(view, projection));
+            try
+            {
+                Letters.ForEach(x => x.Draw(view, projection));
+            } catch (Exception e)
+            {
+                Debug.WriteLine("TextGroup -> Draw Text = {0}: {1}", Text, e.Message);
+            }
         }
 
         public void HandleMouse(HandleMouseCommand command)


### PR DESCRIPTION
Fix crashes for:

- When a model was being set to null. I could have sworn we were doing that elsewhere, but I guess not as I only started seeing the error.
- Somehow the queuedAction was not null and had a value in it, yet currentAction (which was just accessing its first element) was still being set to null. Seems like a freak thing, maybe multi-threaded related, so I just added an extra check to verify it wasn't null.
- Letter drawing sometimes had issues.... seemed to be happening maybe due to changes being made to it on a separate thread. Wrapped in a try catch block and logged the error to the console during debug. Still seems to be mostly rare, maybe related to a draw call just before it's properly initialized? Not sure.