### PR TITLE
Fixed broken save files

### DIFF
--- a/Storage/ConfigStorage.cs
+++ b/Storage/ConfigStorage.cs
@@ -2,6 +2,7 @@ using System;
 using System.Xml.Serialization;
 using System.IO;
 using System.IO.IsolatedStorage;
+using System.Diagnostics;
 
 namespace Backbone.Storage
 {
@@ -17,7 +18,7 @@ namespace Backbone.Storage
             {
                 var isoStore = IsolatedStorageFile.GetStore(IsolatedStorageScope.User | IsolatedStorageScope.Domain | IsolatedStorageScope.Assembly, null, null);
 
-                using (IsolatedStorageFileStream isoStream = new IsolatedStorageFileStream(fileName, FileMode.OpenOrCreate, isoStore))
+                using (IsolatedStorageFileStream isoStream = new IsolatedStorageFileStream(fileName, FileMode.Create, isoStore))
                 {
                     using (StreamWriter writer = new StreamWriter(isoStream))
                     {


### PR DESCRIPTION
Files weren't being fully overwritten and so there was a broken XML n load, this always overwrites the file when saving now.

`</OptionSettings>gs>ttings>s>ngs>`

Apparently it worked sometimes, so I didn't catch on at first, and then eventually it kept saving a smaller file so it always seemed broken.

Switching from FileMode.OpenOrCreate to FileMode.Create fixed the issue.