### PR TITLE
Make alpha based on parent

### DIFF
--- a/Graphics/Movable3D.cs
+++ b/Graphics/Movable3D.cs
@@ -190,7 +190,7 @@ namespace Backbone.Graphics
 
                 var settings = new ModelDrawSettings()
                 {
-                    Alpha = Alpha,
+                    Alpha = Parent != null ? Parent.Alpha * Alpha : Alpha,
                     MeshProperties = MeshProperties,
                     Model = Model,
                     Projection = projection,


### PR DESCRIPTION
Make alpha for child movable be based on alpha for parent movable. Allows adjusting the parent alpha and affecting all children at the same time.