### PR TITLE
Add repeat to rotate

### DIFF
--- a/Actions/ActionAnimationType.cs
+++ b/Actions/ActionAnimationType.cs
@@ -1,0 +1,14 @@
+﻿namespace Backbone.Actions
+{
+    /// <summary>
+    /// Used for determining how the percentage is calculated to show easing or linear. Parametric is the same as EaseInAndOut for most, i.e.
+    /// it slows down at the beginning and the end. Linear is the same speed throughout
+    /// 
+    /// Note: need to update ActionMath.cs when new ones are added.
+    /// </summary>
+    public enum ActionAnimationType
+    {
+        Linear = 0,
+        Parametric = 1,
+    }
+}

--- a/Actions/ActionBuilder.cs
+++ b/Actions/ActionBuilder.cs
@@ -1,9 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using ProximityND.Backbone.Actions;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Backbone.Actions
 {
@@ -20,18 +18,18 @@ namespace Backbone.Actions
             return new FadeToAction(target, duration);
         }
 
-        public static IAction3D RotateX(float target, float duration)
+        public static IAction3D RotateX(float target, float duration, ActionAnimationType animationType = ActionAnimationType.Parametric)
         {
-            return new RotateAction(RotateAction.Coordinate.X, target, duration);
+            return new RotateAction(RotateAction.Coordinate.X, target, duration, animationType);
         }
-        public static IAction3D RotateY(float target, float duration)
+        public static IAction3D RotateY(float target, float duration, ActionAnimationType animationType = ActionAnimationType.Parametric)
         {
-            return new RotateAction(RotateAction.Coordinate.Y, target, duration);
+            return new RotateAction(RotateAction.Coordinate.Y, target, duration, animationType);
         }
 
-        public static IAction3D RotateZ(float target, float duration)
+        public static IAction3D RotateZ(float target, float duration, ActionAnimationType animationType = ActionAnimationType.Parametric)
         {
-            return new RotateAction(RotateAction.Coordinate.Z, target, duration);
+            return new RotateAction(RotateAction.Coordinate.Z, target, duration, animationType);
         }
 
         public static IAction3D MoveBy(Vector3 by, float duration)
@@ -100,6 +98,11 @@ namespace Backbone.Actions
         public static IAction3D ChangeScreen<T>(T switchToScreen)
         {
             return new ChangeScreenAction<T>(switchToScreen);
+        }
+
+        public static IAction3D FunctionCallAction<T>(Func<T> function, T parameter)
+        {
+            return new FunctionCallAction<T>(function, parameter);
         }
 
         /// <summary>

--- a/Actions/ActionMath.cs
+++ b/Actions/ActionMath.cs
@@ -1,7 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Backbone.Actions
 {
@@ -13,18 +11,19 @@ namespace Backbone.Actions
             return sqt / (2.0f * (sqt - t) + 1.0f);
         }
 
-        internal static float LerpFloat(float elapsed, float source, float target, float duration)
+        internal static float LerpFloat(float elapsed, float source, float target, float duration, ActionAnimationType animType = ActionAnimationType.Parametric)
         {
-            float percent = (duration == 0f) ? 1.0f : Math.Min(1.0f, ParametricBlend((float)(elapsed / duration)));
-            var newFloat = source * (1 - percent) + target * percent;
+            float rawPercent = animType == ActionAnimationType.Linear ? (float)(elapsed / duration) : ParametricBlend((float)(elapsed / duration));
+            float clampedPercent = (duration == 0f) ? 1.0f : Math.Min(1.0f, rawPercent);
+            var newFloat = source * (1 - clampedPercent) + target * clampedPercent;
             return newFloat;
         }
 
-
-        internal static Vector3 LerpVector(float elapsed, Vector3 source, Vector3 target, float duration)
+        internal static Vector3 LerpVector(float elapsed, Vector3 source, Vector3 target, float duration, ActionAnimationType animType = ActionAnimationType.Parametric)
         {
-            float percent = (duration == 0f) ? 1.0f : Math.Min(1.0f, ParametricBlend((float)(elapsed / duration)));
-            var newVector = Vector3.Lerp(source, target, percent);
+            float rawPercent = animType == ActionAnimationType.Linear ? (float)(elapsed / duration) : ParametricBlend((float)(elapsed / duration));
+            float clampedPercent = (duration == 0f) ? 1.0f : Math.Min(1.0f, rawPercent);
+            var newVector = Vector3.Lerp(source, target, clampedPercent);
             return newVector;
         }
     }

--- a/Actions/ChangeObjectPropertyAction.cs
+++ b/Actions/ChangeObjectPropertyAction.cs
@@ -1,16 +1,10 @@
-﻿using Backbone.Actions;
-using Backbone.Graphics;
-using Backbone.RPG;
+﻿using Backbone.Graphics;
 using Microsoft.Xna.Framework;
-using SharpDX.Direct3D9;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace ProximityND.Backbone.Actions
+namespace Backbone.Actions
 {
     /// <summary>
     /// Takes in an object, a string name of a property on that object, and a new value, and will change the property of that object

--- a/Actions/ColorAction.cs
+++ b/Actions/ColorAction.cs
@@ -1,10 +1,8 @@
-﻿using Backbone.Actions;
-using Backbone.Graphics;
+﻿using Backbone.Graphics;
 using Microsoft.Xna.Framework;
-using SharpDX.MediaFoundation;
 using System.Collections.Generic;
 
-namespace ProximityND.Backbone.Actions
+namespace Backbone.Actions
 {
     // TODO: make this generic and not just based on color1 and color2 (use mesh color properties instead)
     public class ColorAction : IAction3D

--- a/Actions/RotateAction.cs
+++ b/Actions/RotateAction.cs
@@ -11,6 +11,8 @@ namespace Backbone.Actions
         public enum Coordinate { X, Y, Z }
         public List<IAction3D> SubActions { get; set; }
 
+        public bool RepeatForever { get; set; } = false;
+
         private float target;
         private float duration;
         private Coordinate coordinate;
@@ -71,7 +73,18 @@ namespace Backbone.Actions
                     break;
             }
 
-            return (elapsedTime >= duration);
+            if (elapsedTime >= duration)
+            {
+                if(RepeatForever)
+                {
+                    elapsedTime -= duration;
+                } else
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
     }

--- a/Actions/RotateAction.cs
+++ b/Actions/RotateAction.cs
@@ -1,8 +1,6 @@
 ﻿using Backbone.Graphics;
 using Microsoft.Xna.Framework;
-using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Backbone.Actions
 {
@@ -20,12 +18,14 @@ namespace Backbone.Actions
         private bool hasStarted = false;
         private float source = 0f;
         private float elapsedTime = 0f;
+        private ActionAnimationType animationType;
 
-        public RotateAction(Coordinate coordinate, float rotateAmount, float duration)
+        public RotateAction(Coordinate coordinate, float rotateAmount, float duration, ActionAnimationType animationType)
         {
             this.target = rotateAmount;
             this.duration = duration;
             this.coordinate = coordinate;
+            this.animationType = animationType;
         }
 
         public void Reset()
@@ -58,7 +58,12 @@ namespace Backbone.Actions
                 }
             }
 
-            currentFloat = ActionMath.LerpFloat(elapsedTime, source, target, duration);
+            if (elapsedTime >= duration && RepeatForever)
+            {
+                elapsedTime -= duration;
+            }
+
+            currentFloat = ActionMath.LerpFloat(elapsedTime, source, target, duration, animationType);
             
             switch(coordinate)
             {
@@ -73,15 +78,9 @@ namespace Backbone.Actions
                     break;
             }
 
-            if (elapsedTime >= duration)
+            if (elapsedTime >= duration && !RepeatForever)
             {
-                if(RepeatForever)
-                {
-                    elapsedTime -= duration;
-                } else
-                {
-                    return true;
-                }
+                return true;
             }
 
             return false;

--- a/Events/PubHub.cs
+++ b/Events/PubHub.cs
@@ -151,6 +151,8 @@ namespace Backbone.Events
                 if(kvp.Value.Contains(subscriber))
                 {
                     Subscriptions[kvp.Key].Remove(subscriber);
+                    RegisteredGroupActions.Clear();
+                    Prerequisites.Clear();
                 }
             }
         }

--- a/Graphics/Movable3D.cs
+++ b/Graphics/Movable3D.cs
@@ -115,7 +115,7 @@ namespace Backbone.Graphics
 
         }
 
-        private void UpdateMatrix()
+        public void UpdateMatrix()
         {
             float rotXRadians = (Parent != null) ? DegToRad(RotationX + Parent.RotationX) : DegToRad(RotationX);
             float rotYRadians = (Parent != null) ? DegToRad(RotationY + Parent.RotationY) : DegToRad(RotationY);
@@ -223,6 +223,11 @@ namespace Backbone.Graphics
         {
             Position = newPosition;
             UpdateMatrix();
+        }
+
+        public void ClearAnimations()
+        {
+            queuedActions.Clear();
         }
 
         public void UpdateColor(string meshName, string newColor)

--- a/Graphics/Particles/ParticleEmitter.cs
+++ b/Graphics/Particles/ParticleEmitter.cs
@@ -1,6 +1,7 @@
 ﻿using Backbone.Input;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using System;
 using System.Collections.Generic;
 
 namespace Backbone.Graphics.Particles
@@ -39,6 +40,21 @@ namespace Backbone.Graphics.Particles
                 particles.Add(new Particle(particleModel, position, velocity, angularVelocity, particleLife, particleGravity, particleScale));
             }
         }
+
+        public void Emit(Vector3 position, Func<Vector3> velocityFunction, Vector3 angularVelocity, int count)
+        {
+            if (shouldInvertY)
+            {
+                position.Y = graphicsDevice.Viewport.Height - position.Y;
+            }
+
+            for (int i = 0; i < count; i++)
+            {
+                var velocity = velocityFunction.Invoke();
+                particles.Add(new Particle(particleModel, position, velocity, angularVelocity, particleLife, particleGravity, particleScale));
+            }
+        }
+
 
         public void Update(GameTime gameTime)
         {


### PR DESCRIPTION
Several fixes and minor enhancements to support new feature in Proximity where I was adding spinning medals and particles to celebrate winning or losing a match.

- Fixed issue where PreRequisites and RegisteredGroupActions were never getting cleared. Now they will during an UnsubscribeAll (which I call whenever I leave a Screen currently)
- Added ability to repeat the rotate action forever, which I use for spinning medals in my game. Can add this to other animations later
- Added ability to set rotate animation easing to linear. It was always EaseInAndOut before (I called it Parametric based on the equation I used). Can easily be added to any of the actions that use lerp functions as well, I was just being a bit lazy about it. Keeping default as parametric though.
- Noticed the particle emitter was always shooting out stars in the same direction (thought it wasn't for some reason). Added a velocity function to it so I can pass a function to randomize the velocity (or whatever) so they're not all the same.
- Added an ability to clear animations on a Movable from it. Even more necessary now that there are animations that never end that can be run on them.
- Various cleanup. Namely I saw that some things I created recently had a reference to the Proximity namespace and that shouldn't be the case, so I removed that.