### PR TITLE
Graph fixes

### DIFF
--- a/Graphics/Graph3D.cs
+++ b/Graphics/Graph3D.cs
@@ -3,6 +3,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 namespace Backbone.Graphics
@@ -118,9 +119,12 @@ namespace Backbone.Graphics
 
             var xNumberRange = horizontalAxisSettings.MaxValue - horizontalAxisSettings.MinValue;
             var xAxisPositionXGap = (int)(Width / (horizontalAxisSettings.NumSegments - 1));
+
+            var xAxisValues = getAxisValues(horizontalAxisSettings, xNumberRange, horizontalAxisSettings.NumSegments);
+
             for (var i = 1; i < horizontalAxisSettings.NumSegments; i++)
             {
-                var xAxisValue = (int)Math.Floor(horizontalAxisSettings.MinValue + (int)Math.Ceiling((float)(xNumberRange * (i + 1))) / (float)verticalAxisSettings.NumSegments);
+                var xAxisValue = (int)Math.Floor(horizontalAxisSettings.MinValue + (int)Math.Ceiling((float)(xNumberRange * (i + 1))) / (float)horizontalAxisSettings.NumSegments);
 
                 var horizNumSegment = new TextGroup(new TextGroupSettings()
                 {
@@ -130,7 +134,7 @@ namespace Backbone.Graphics
                     Parent = Movable3D.Empty(),
                     Position = new Vector3(Origin.X + xAxisPositionXGap * i + 10.0f, Origin.Y - 40f, -1),
                     Scale = axisLabelScale,
-                    Text = xAxisValue.ToString(),
+                    Text = xAxisValues[i],
                 });
                 horizontalAxisLabels.Add(horizNumSegment);
             }
@@ -150,10 +154,10 @@ namespace Backbone.Graphics
             var yNumberRange = verticalAxisSettings.MaxValue - verticalAxisSettings.MinValue;
             var yAxisPositionXGap = (int)(Height / (verticalAxisSettings.NumSegments - 1));
 
+            var yAxisValues = getAxisValues(verticalAxisSettings, yNumberRange, verticalAxisSettings.NumSegments);
+
             for (var i = 1; i < verticalAxisSettings.NumSegments; i++)
             {
-                var yAxisValue = (int)Math.Floor(verticalAxisSettings.MinValue + (int)Math.Ceiling((float)(yNumberRange * (i + 1))) / (float)verticalAxisSettings.NumSegments);
-
                 var vertNumSegment = new TextGroup(new TextGroupSettings()
                 {
                     Alignment = UI.TextAlign.Left,
@@ -162,10 +166,37 @@ namespace Backbone.Graphics
                     Parent = Movable3D.Empty(),
                     Position = new Vector3(Origin.X + Width + 25.0f, Origin.Y + yAxisPositionXGap * i, -1),
                     Scale = axisLabelScale,
-                    Text = yAxisValue.ToString(),
+                    Text = yAxisValues[i],
                 });
                 verticalAxisLabels.Add(vertNumSegment);
             }
+        }
+
+        private string[] getAxisValues(AxisSettings axisSettings, int numberRange, int numSegments)
+        {
+            var axisValues = new string[axisSettings.NumSegments];
+
+            for (var i = 1; i < axisSettings.NumSegments; i++)
+            {
+                var axisValue = ((int)Math.Floor(axisSettings.MinValue + (int)Math.Ceiling((float)(numberRange * (i + 1))) / (float)numSegments)).ToString();
+                axisValues[i] = axisValue;
+            }
+
+            //now loop through backwards and remove anything that matches the most recent valid value (don't need to show multiple times)
+            var previousValue = string.Empty;
+            for (var i = axisValues.Length - 1; i > 0; i--)
+            {
+                if (axisValues[i] == previousValue)
+                {
+                    axisValues[i] = string.Empty;
+                }
+                else
+                {
+                    previousValue = axisValues[i];
+                }
+            }
+
+            return axisValues;
         }
 
         public void SetGraphData(List<GraphData> graphData)

--- a/Graphics/TransitionState.cs
+++ b/Graphics/TransitionState.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ProximityND.Backbone.Graphics
+{
+    public enum TransitionState
+    {
+        None,
+        In,
+        Out,
+    }
+}


### PR DESCRIPTION
Added transition in and out with basic fade alpha to graph.

Adjusted positions of outer vertical grid lines and some overlap for the data lines so they don't look so disjointed.

Removed duplicate axis values from the labels, so if before it had ['0', '0', '0', '0', '0', '1'], it will now show [ '','','','','0','1']. Note, this isn't perfect even though, which isn't ideal. Like the number look weird and grouped together. But this should only be an issue in the first few turns anyway, so I'm not sure how much I want to properly fix this, at least right now.
